### PR TITLE
Fixed the issue of page not reloading after the partnership is confirmed

### DIFF
--- a/web/src/AttestationItem.tsx
+++ b/web/src/AttestationItem.tsx
@@ -159,6 +159,8 @@ export function AttestationItem({ data }: Props) {
                   schema: CUSTOM_SCHEMAS.CONFIRM_SCHEMA,
                 });
 
+                const uid = await tx.wait();
+
                 setConfirming(false);
                 window.location.reload();
               } catch (e) {}


### PR DESCRIPTION
After the partner company confirm the partnership a company stated, the page should reload in order to show the success of the operation.
I added an await block to make the confirming operation wait until success before changing state.
